### PR TITLE
fixed: option not getting added when value is 0 or false

### DIFF
--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -70,7 +70,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
         foreach ($defaultWsdlOptions as $optionName => $optionValue) {
             if (array_key_exists($optionName, $options) && !empty($options[$optionName])) {
                 $wsdlOptions[str_replace(self::OPTION_PREFIX, '', $optionName)] = $options[$optionName];
-            } elseif (!empty($optionValue)) {
+            } elseif (isset($optionValue)) {
                 $wsdlOptions[str_replace(self::OPTION_PREFIX, '', $optionName)] = $optionValue;
             }
         }


### PR DESCRIPTION
example, when there is 'wsdl_cache_wsdl' => 0 in the $options array