### PR TITLE
Fix WSDL_CACHE_WSDL not working

### DIFF
--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -68,7 +68,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
         $wsdlOptions = [];
         $defaultWsdlOptions = static::getDefaultWsdlOptions();
         foreach ($defaultWsdlOptions as $optionName => $optionValue) {
-            if (array_key_exists($optionName, $options) && !empty($options[$optionName])) {
+            if (array_key_exists($optionName, $options)) {
                 $wsdlOptions[str_replace(self::OPTION_PREFIX, '', $optionName)] = $options[$optionName];
             } elseif (!empty($optionValue)) {
                 $wsdlOptions[str_replace(self::OPTION_PREFIX, '', $optionName)] = $optionValue;


### PR DESCRIPTION
This fixes issue #19 by removing the `!empty` check.  Zero and empty strings are valid options so this check silently discards things which it should not!