### PR TITLE
properly explode newlines from streamContext headers

### DIFF
--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -387,6 +387,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
         $context = $this->getStreamContext();
         if ($context !== null) {
             $options = stream_context_get_options($context);
+            $options['http']['header'] = array_filter(explode(PHP_EOL, $options['http']['header']));
         }
         return $options;
     }

--- a/tests/SoapClientTest.php
+++ b/tests/SoapClientTest.php
@@ -363,8 +363,8 @@ class SoapClientTest extends TestCase
         $this->assertSame(array(
             'X-HEADER' => 'X-VALUE',
         ), $o['http']['Auth']);
-        $this->assertTrue(strpos($o['http']['header'], 'X-Header-Name: X-Header-Value') !== false);
-        $this->assertTrue(strpos($o['http']['header'], 'X-Header-ID: X-Header-ID-Value') !== false);
+        $this->assertContains('X-Header-Name: X-Header-Value', $o['http']['header']);
+        $this->assertContains('X-Header-ID: X-Header-ID-Value', $o['http']['header']);
     }
     /**
      *


### PR DESCRIPTION
In order to receive an array of headers which are then later used within the package, it is required to explode default EOL merged headers into separate array elements. Otherwise successive calls using the merged headers will fail