### PR TITLE
The parameter soapClientClassName

### DIFF
--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -67,7 +67,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
                 $wsdlUrl = $wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)];
                 unset($wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)]);
             }
-            $soapClientClassName = $this->getSoapClientClassName();
+            $soapClientClassName = $this->getSoapClientClassName($options['SoapClient'] ?? null);
             $this->setSoapClient(new $soapClientClassName($wsdlUrl, $wsdlOptions));
         }
     }


### PR DESCRIPTION
# The parameter "soapClientClassName" with the value of the option "DEFAULT_SOAP_CLIENT_CLASS"

```php
/**
 * @see SoapClient::__doRequest()
 */
class MySoapClient extends \SoapClient
{
    /**
     * @see SoapClient::__doRequest()
     */
    public function __doRequest($request, $location, $action, $version, $one_way = 0)
    {
        // Overwrite method
        return parent::__doRequest($request, $location, $action, $version, $one_way);
    }
}

/**
 * Minimal options
 */
$options = [
     WsdlToPhp\PackageBase\AbstractSoapClientBase::WSDL_URL => 'WSDL'
     WsdlToPhp\PackageBase\AbstractSoapClientBase::WSDL_CACHE_WSDL => true,
     WsdlToPhp\PackageBase\AbstractSoapClientBase::WSDL_SOAP_VERSION => SOAP_1_2,
     WsdlToPhp\PackageBase\AbstractSoapClientBase::WSDL_CLASSMAP => ClassMap::get(),
     WsdlToPhp\PackageBase\AbstractSoapClientBase::DEFAULT_SOAP_CLIENT_CLASS => MySoapClient::class, // USE SOAP CLASS
];

/**
 * Samples for Get ServiceType
 */
 $ws = new Get($options);
```