### PR TITLE
Fixes #42 SoapClient->_stream_context is private in php 8

### DIFF
--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -69,7 +69,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
                 $wsdlUrl = $wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)];
                 unset($wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)]);
             }
-            $this->streamContext = stream_context_create();
+            $this->streamContext = $wsdlOptions['stream_context'] ?? stream_context_create();
             $wsdlOptions['stream_context'] = $this->streamContext;
             $soapClientClassName = $this->getSoapClientClassName();
             $this->soapClient = new $soapClientClassName($wsdlUrl, $wsdlOptions);

--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -18,6 +18,13 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
     private ?SoapClient $soapClient = null;
 
     /**
+     * The SoapClient's stream context.
+     * Stored separately since SoapClient->_stream_context is private in php 8.
+     * @var resource|null
+     */
+    private $streamContext = null;
+
+    /**
      * Contains Soap call result
      * @var mixed
      */
@@ -45,11 +52,6 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
         return $this->soapClient;
     }
 
-    public function setSoapClient(SoapClient $soapClient): SoapClient
-    {
-        return ($this->soapClient = $soapClient);
-    }
-
     public function initSoapClient(array $options): void
     {
         $wsdlOptions = [];
@@ -67,8 +69,10 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
                 $wsdlUrl = $wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)];
                 unset($wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)]);
             }
+            $this->streamContext = stream_context_create();
+            $wsdlOptions['stream_context'] = $this->streamContext;
             $soapClientClassName = $this->getSoapClientClassName();
-            $this->setSoapClient(new $soapClientClassName($wsdlUrl, $wsdlOptions));
+            $this->soapClient = new $soapClientClassName($wsdlUrl, $wsdlOptions);
         }
     }
 
@@ -302,20 +306,14 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
     public function setHttpHeader(string $headerName, $headerValue): bool
     {
         $state = false;
-        if ($this->getSoapClient() && !empty($headerName)) {
-            $streamContext = $this->getStreamContext();
-            if ($streamContext === null) {
-                $options = [];
+        $streamContext = $this->getStreamContext();
+        if ($this->getSoapClient() && $streamContext && !empty($headerName)) {
+            $options = stream_context_get_options($streamContext);
+            if (!array_key_exists('http', $options) || !is_array($options['http'])) {
                 $options['http'] = [];
                 $options['http']['header'] = '';
-            } else {
-                $options = stream_context_get_options($streamContext);
-                if (!array_key_exists('http', $options) || !is_array($options['http'])) {
-                    $options['http'] = [];
-                    $options['http']['header'] = '';
-                } elseif (!array_key_exists('header', $options['http'])) {
-                    $options['http']['header'] = '';
-                }
+            } elseif (!array_key_exists('header', $options['http'])) {
+                $options['http']['header'] = '';
             }
             if (count($options) && array_key_exists('http', $options) && is_array($options['http']) && array_key_exists('header', $options['http']) && is_string($options['http']['header'])) {
                 $lines = explode("\r\n", $options['http']['header']);
@@ -336,17 +334,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
                  * Set the context http header option
                  */
                 $options['http']['header'] = implode("\r\n", $newLines);
-                /**
-                 * Create context if it does not exist
-                 */
-                if ($streamContext === null) {
-                    $state = is_resource($this->getSoapClient()->_stream_context = stream_context_create($options));
-                } else {
-                    /**
-                     * Set the new context http header option
-                     */
-                    $state = stream_context_set_option($this->getSoapClient()->_stream_context, 'http', 'header', $options['http']['header']);
-                }
+                $state = stream_context_set_option($this->streamContext, 'http', 'header', $options['http']['header']);
             }
         }
 
@@ -359,7 +347,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
      */
     public function getStreamContext()
     {
-        return ($this->getSoapClient() && isset($this->getSoapClient()->_stream_context) && is_resource($this->getSoapClient()->_stream_context)) ? $this->getSoapClient()->_stream_context : null;
+        return $this->streamContext;
     }
 
     /**


### PR DESCRIPTION
SoapClient->_stream_context is private in php8.
To work around that a stream context is systematically created during init and provided to SoapClient.

Another aproach I tried before was to get access to SoapClient->_stream_context through reflection or a closure.
That trick does not work for php internal classes, and felt a bit hacky.

I had to remove AbstractSoapClientBase->setSoapClient, since we lose access to the stream context if SoapClient is created externally.
That's a potential breaking change.