### PR TITLE
Update AbstractSoapClientBase.php

### DIFF
--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -61,11 +61,24 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
                 $wsdlOptions[str_replace(self::OPTION_PREFIX, '', $optionName)] = $optionValue;
             }
         }
+        
+         foreach ($options as $optionName => $optionValue) {
+            if (!array_key_exists($optionName, $defaultWsdlOptions) && !is_null($optionValue)) {
+                $wsdlOptions[$optionName] = $optionValue;
+            }
+        }
+        
         if (self::canInstantiateSoapClientWithOptions($wsdlOptions)) {
             $wsdlUrl = null;
             if (array_key_exists(str_replace(self::OPTION_PREFIX, '', self::WSDL_URL), $wsdlOptions)) {
                 $wsdlUrl = $wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)];
                 unset($wsdlOptions[str_replace(self::OPTION_PREFIX, '', self::WSDL_URL)]);
+            }
+            
+            if ($wsdlOptions['stream_context'] ==null){
+                $this->streamContext = stream_context_create();
+                $wsdlOptions['stream_context'] = $this->streamContext;
+
             }
             $soapClientClassName = $this->getSoapClientClassName();
             $this->setSoapClient(new $soapClientClassName($wsdlUrl, $wsdlOptions));


### PR DESCRIPTION
As an enhancement (?) , for those who need to change the http header globally, we could allow stream_context to be passed through options once so it would not be necessary to call setHttpHeader() before each request.

The code for including some header would be : 

$options = array(
   \WsdlToPhp\PackageBase\AbstractSoapClientBase::WSDL_URL => 'https://somewebservice?wsdl',
    \WsdlToPhp\PackageBase\AbstractSoapClientBase::WSDL_CLASSMAP => ClassMap::get(),
);

$aHTTP['http']['header'] =  "myheader: myheadervalue"; $context = stream_context_create($aHTTP);
$options2=array_merge($options,array("stream_context" => $context));

$someservice = new \ServiceType\SomeServiceClass($options2);