### PR TITLE
Fix overriding the custom SoapClient class

### DIFF
--- a/src/AbstractSoapClientBase.php
+++ b/src/AbstractSoapClientBase.php
@@ -100,7 +100,7 @@ abstract class AbstractSoapClientBase implements SoapClientInterface
      */
     public function getSoapClientClassName(?string $soapClientClassName = null): string
     {
-        $className = self::DEFAULT_SOAP_CLIENT_CLASS;
+        $className = static::DEFAULT_SOAP_CLIENT_CLASS;
         if (!empty($soapClientClassName) && is_subclass_of($soapClientClassName, SoapClient::class)) {
             $className = $soapClientClassName;
         }

--- a/tests/CustomSoapClientService.php
+++ b/tests/CustomSoapClientService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WsdlToPhp\PackageBase\Tests;
+
+use WsdlToPhp\PackageBase\AbstractSoapClientBase;
+
+/**
+ * Services can specify a custom SoapClient class
+ * to be used instead of PHP default by overriding
+ * the constant below.
+ * 
+ * @see \WsdlToPhp\PackageBase\SoapClientInterface
+ * @see \WsdlToPhp\PackageBase\AbstractSoapClientBase :: getSoapClientClassName()
+ */
+
+class CustomSoapClientService extends AbstractSoapClientBase
+{
+
+    /**
+     * Custom SoapClient class used for current service.
+     */
+    const DEFAULT_SOAP_CLIENT_CLASS = Client::class;
+    
+}

--- a/tests/DefaultSoapClientService.php
+++ b/tests/DefaultSoapClientService.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WsdlToPhp\PackageBase\Tests;
+
+use WsdlToPhp\PackageBase\AbstractSoapClientBase;
+
+/**
+ * By default all services extending the packagebase's
+ * abstract class rely on PHP's default SoapClient.
+ */
+
+class DefaultSoapClientService extends AbstractSoapClientBase
+{
+
+}

--- a/tests/SoapClientTest.php
+++ b/tests/SoapClientTest.php
@@ -25,6 +25,15 @@ class SoapClientTest extends TestCase
         $this->assertSame(Client::class, $soapClient->getSoapClientClassName(Client::class));
     }
 
+    public function testCustomSoapClientNameReadFromConstant()
+    {
+        $defaultService = new DefaultSoapClientService();
+        $customService  = new CustomSoapClientService();
+
+        $this->assertSame(SoapClientBase::class, $defaultService->getSoapClientClassName());
+        $this->assertSame(Client::class, $customService->getSoapClientClassName());
+    }
+
     public function testSoapClient(): void
     {
         $soapClient = new SoapClient([
@@ -489,4 +498,5 @@ class SoapClientTest extends TestCase
         $this->assertTrue(is_array($soapClient->getOutputHeaders()));
         $this->assertEmpty($soapClient->getOutputHeaders());
     }
+
 }


### PR DESCRIPTION
Hey,

in general all services extending the `AbstractSoapClientBase` class use PHP's default `SoapClient` class to handle requests, which is specified as a constant in the `SoapClientInterface`: `DEFAULT_SOAP_CLIENT_CLASS`.

As per documentation, a custom SoapClient class can be used by overriding said constant:

> _**DEFAULT_SOAP_CLIENT_CLASS = '\SoapClient'**: this is the default [SoapClient](http://php.net/manual/en/class.soapclient.php) class that is used to send the request. Feel free to override it if you want to use another [SoapClient](http://php.net/manual/en/class.soapclient.php) class_

However, simply overriding it does not work since the underlying SoapClient initialization method (`initSoapClient()`) relies on the value returned by the `getSoapClientClassName()` method which in turn reads the constant as a `self::`, i.e. as defined in the actual abstract class (or the interface in this case). Kind of like reading a private property inside a parent class – overriding in the child class has no effect.

If we use late static bindings on the other hand, it would read the constant's value from the extended class first, and then use the interface constant as a fallback: `static::` instead of `self::`. Like turning a private property protected.

Currently, if my service extends the `AbstractSoapClientBase` class using all its functionality, but I decide to use a custom `SoapClient`, I would have to override the `getSoapClientClassName()` method in my service class. It would be easier if I could just specify it by overriding the `DEFAULT_SOAP_CLIENT_CLASS` constant – like the documentation suggests I should do :blush: 